### PR TITLE
Add AWS Lambda deployment support

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,0 +1,29 @@
+FROM node:20-alpine AS build
+RUN npm install -g pnpm@8
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+WORKDIR /app
+COPY . /app
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN pnpm --filter @delivery-tracker/server build-with-deps
+
+FROM public.ecr.aws/lambda/nodejs:20
+
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+RUN npm install -g pnpm@8
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/api/package.json packages/api/
+COPY packages/core/package.json packages/core/
+COPY packages/server/package.json packages/server/
+
+RUN pnpm install --prod --frozen-lockfile
+
+COPY --from=build /app/packages/api/dist packages/api/dist
+COPY --from=build /app/packages/core/dist packages/core/dist
+COPY --from=build /app/packages/server/dist packages/server/dist
+
+CMD ["packages/server/dist/lambda.handler"]

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,29 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
+      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build -f Dockerfile.lambda -t $REPOSITORY_URI:latest .
+      - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:latest
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - |
+        if [ -n "$LAMBDA_FUNCTION_NAME" ]; then
+          echo Updating Lambda function...
+          aws lambda update-function-code --function-name $LAMBDA_FUNCTION_NAME --image-uri $REPOSITORY_URI:latest
+        fi

--- a/packages/server/src/lambda.ts
+++ b/packages/server/src/lambda.ts
@@ -1,0 +1,113 @@
+import type * as winston from "winston";
+import { ApolloServer } from "@apollo/server";
+import {
+  ApolloServerErrorCode,
+  unwrapResolverError,
+} from "@apollo/server/errors";
+import { typeDefs, resolvers, type AppContext } from "@delivery-tracker/api";
+import {
+  DefaultCarrierRegistry,
+  logger as coreLogger,
+} from "@delivery-tracker/core";
+import { initLogger } from "./logger";
+
+const serverRootLogger: winston.Logger = coreLogger.rootLogger.child({
+  module: "server",
+});
+
+const server = new ApolloServer({
+  typeDefs,
+  resolvers: resolvers.resolvers,
+  formatError: (formattedError, error) => {
+    const extensions = formattedError.extensions ?? {};
+    switch (extensions.code) {
+      case "INTERNAL":
+      case "BAD_REQUEST":
+      case "NOT_FOUND":
+      case ApolloServerErrorCode.INTERNAL_SERVER_ERROR:
+        extensions.code = "INTERNAL";
+        break;
+      case ApolloServerErrorCode.GRAPHQL_PARSE_FAILED:
+        extensions.code = "BAD_REQUEST";
+        break;
+      case ApolloServerErrorCode.GRAPHQL_VALIDATION_FAILED:
+        extensions.code = "BAD_REQUEST";
+        break;
+      case ApolloServerErrorCode.PERSISTED_QUERY_NOT_FOUND:
+        extensions.code = "BAD_REQUEST";
+        break;
+      case ApolloServerErrorCode.PERSISTED_QUERY_NOT_SUPPORTED:
+        extensions.code = "BAD_REQUEST";
+        break;
+      case ApolloServerErrorCode.BAD_USER_INPUT:
+        extensions.code = "BAD_REQUEST";
+        break;
+      case ApolloServerErrorCode.OPERATION_RESOLUTION_FAILURE:
+        extensions.code = "BAD_REQUEST";
+        break;
+      default:
+        extensions.code = "INTERNAL";
+        break;
+    }
+
+    if (extensions.code === "INTERNAL") {
+      serverRootLogger.error("internal error response", {
+        formattedError,
+        error: unwrapResolverError(error),
+      });
+    }
+
+    return {
+      ...formattedError,
+      extensions,
+      message:
+        extensions.code === "INTERNAL"
+          ? "Internal error"
+          : formattedError.message,
+    };
+  },
+});
+
+const carrierRegistry = new DefaultCarrierRegistry();
+let initialized = false;
+
+interface LambdaEvent {
+  query: string;
+  variables?: Record<string, unknown>;
+  operationName?: string;
+}
+
+interface LambdaResponse {
+  data?: Record<string, unknown> | null;
+  errors?: ReadonlyArray<{
+    message: string;
+    extensions?: Record<string, unknown>;
+  }>;
+}
+
+export const handler = async (event: LambdaEvent): Promise<LambdaResponse> => {
+  if (!initialized) {
+    initLogger();
+    await server.start();
+    await carrierRegistry.init();
+    initialized = true;
+  }
+
+  const appContext: AppContext = {
+    carrierRegistry,
+  };
+
+  const result = await server.executeOperation(
+    {
+      query: event.query,
+      variables: event.variables,
+      operationName: event.operationName,
+    },
+    { contextValue: { appContext } }
+  );
+
+  if (result.body.kind === "single") {
+    return result.body.singleResult;
+  }
+  return { errors: [{ message: "Incremental delivery not supported" }] };
+};


### PR DESCRIPTION
## Summary
- Add `lambda.ts` handler for direct Lambda invoke via AWS SDK (no HTTP/API Gateway)
- Add `Dockerfile.lambda` for Lambda container image build
- Add `buildspec.yml` for CodeBuild CI/CD pipeline

## Test plan
- [ ] Build Docker image with `docker build -f Dockerfile.lambda -t delivery-tracker .`
- [ ] Test Lambda locally or deploy to AWS
- [ ] Verify GraphQL queries work via `lambda.invoke()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)